### PR TITLE
use before load event to cover all page transitions

### DIFF
--- a/cypress/integration/test_spec.js
+++ b/cypress/integration/test_spec.js
@@ -1,10 +1,11 @@
 describe('testing popup function', () => {
     it('navigates to index and stubs window.open', () => {
-        cy.visit('index.html', {
-            onBeforeLoad: (win) => {
-                cy.stub(win, 'open');
-            }
-        });
+        cy.on('window:before:load', (win) => {
+            cy.stub(win, 'open')
+            console.log('page transition')
+        })
+
+        cy.visit('index.html');
 
         cy.window().then(function (win) {
             cy.get('button').click()


### PR DESCRIPTION
using `window:before:load` event seems to work as it covers every page transition
https://docs.cypress.io/api/events/catalog-of-events#Window-Before-Load